### PR TITLE
Add definition of variable in Tutorial/Merging_regulation.m

### DIFF
--- a/Tutorial/Merging_regulation.m
+++ b/Tutorial/Merging_regulation.m
@@ -11,6 +11,7 @@ load('Surrogate_dim2')
 
 %% 1D regulation  
 TRS_1D_result = zeros(num_component,1);
+regulation_network_dim1 = zeros(num_component);
 for i = 1:num_component
     % indexing all the causes of each target
     index_list = [];


### PR DESCRIPTION
Definition of variable 'regulation_network_dim1' was missing in Tutorial/Merging_regulation.m file, so I added definition as in figure generating codes.

https://github.com/Mathbiomed/GOBI/blob/04f5ab3a16b81d5a48517616206457767fe14486/Figures/Fig3j_Feedforward_loops/merge_network.m#L18-L20